### PR TITLE
Dockerfile: Create /app/storage while build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:10-alpine
 RUN mkdir -p /app/node_modules
 WORKDIR /app
 COPY . /app
-RUN rm -rf /app/mode_modules/* && chown -R node:node /app
+RUN mkdir /app/storage && rm -rf /app/mode_modules/* && chown -R node:node /app
 USER node
 RUN npm install
 RUN npm run build


### PR DESCRIPTION
The directory `/app/storage` has never exist before.
Normally this is not a real problem, until you want to use docker volumes. If you mount a docker volume to `/app/storage`, then it can happen that you get a `permission denied` stacktrace. The reason is that the application is running with User-ID `1000` (in this container it is the `node` user) and not as `root` (User-ID `0`). This should not be changed for security.

The simplest solution is to create the folder before mount and change the owner to `node` (User-ID `1000`) which is implemented in this PR.

The test shows a functional MyPaste container where also the data are now in a volume.